### PR TITLE
Fix code example syntax highlighting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ $ yarn add --dev mdx-deck-code-surfer raw-loader
 
 And then use it from your `.mdx`:
 
-```mdx
+```jsx
 ---
 
 import { CodeSurfer } from "mdx-deck-code-surfer"


### PR DESCRIPTION
Although `mdx` is correct, GitHub doesn't support it yet. `jsx` gives syntax highlighting that works now :)

Before:
![image](https://user-images.githubusercontent.com/5497885/44697013-28d87e00-aa37-11e8-8117-5552568424ce.png)

After:
![image](https://user-images.githubusercontent.com/5497885/44697026-40b00200-aa37-11e8-889a-2f58086052e2.png)

p.s. Thanks for such a fantastic library!