### PR TITLE
🐛 FIX: Typo in the SOP Theme Name

### DIFF
--- a/packages/mdx-deck-code-surfer/docs/snippets/shades-of-purple.mdx
+++ b/packages/mdx-deck-code-surfer/docs/snippets/shades-of-purple.mdx
@@ -1,7 +1,7 @@
 import shadesOfPurple from "prism-react-renderer/themes/shadesOfPurple"
 
 <CodeSurfer
-  title="Shades of Purlple"
+  title="🦄 Shades of Purple"
   theme={shadesOfPurple}
   notes="⬇️"
   code={require("!raw-loader!./snippets/shades-of-purple.mdx")}


### PR DESCRIPTION
Address `purlple` typo with `🦄 Shades of Purple`