### PR TITLE
stop raf loop when done

### DIFF
--- a/packages/code-surfer/src/scroller.js
+++ b/packages/code-surfer/src/scroller.js
@@ -77,6 +77,7 @@ const scrollTo = (container, content, center, scale, duration) => {
   const endY = center;
 
   let step = { top: startY, scale: startScale };
+  let shouldAnimate = true;
 
   const tween = new TWEEN.Tween(step)
     .to({ top: endY, scale }, duration)
@@ -85,9 +86,13 @@ const scrollTo = (container, content, center, scale, duration) => {
       container.scrollTop = step.top | 0;
       content.style.transform = "scale(" + step.scale + ")";
     })
+    .onComplete(() => {
+      shouldAnimate = false;
+    })
     .start();
 
   function animate(time) {
+    if (!shouldAnimate) return;
     requestAnimationFrame(animate);
     TWEEN.update(time);
   }


### PR DESCRIPTION
Hi, thanks for your work on this fantastic library.

I have an mdx-deck with several code surfer components, and I've been puzzled why the performance of some animation demos elsewhere in the deck was so bad, when those same demos worked fine in other environments. In chrome devtools I saw dozens of `requestAnimationFrame` calls every frame that I did not initiate. I traced them to a file called scroller.js, located in the code-surfer repo. 

It turns out there were zombie request animation frame loops being initiated but never stopped by code-surfer. I assume this wouldn't be a problem for a tiny deck, but it was a problem for mine.

 I don't know if my pr is the *best* way to solve the problem, but at least it does seem to work when I test it on my deck. I can post chrome devtools comparisons as well if you would like. 