### PR TITLE
Fix notes by rendering Notes from mdx-deck

### DIFF
--- a/fixtures/sample/sample.mdx
+++ b/fixtures/sample/sample.mdx
@@ -117,6 +117,10 @@ export const theme = {
   ]}
 />
 
+```notes
+And you can still add regular notes the ol' fashioned way!
+```
+
 ---
 
 ```jsx Global Theming

--- a/packages/mdx-deck-code-surfer/src/deck-components.js
+++ b/packages/mdx-deck-code-surfer/src/deck-components.js
@@ -1,11 +1,14 @@
 import React from "react";
+import { Notes } from "mdx-deck";
 import DeckCodeSurfer from "./deck-code-surfer";
+
+const getLanguage = className => className.slice(9);
 
 class Code extends React.PureComponent {
   render() {
     const { children, metaString, className } = this.props;
     const [src, steps] = children.split("\n----");
-    const language = className.slice(9);
+    const language = getLanguage(className);
     return (
       <DeckCodeSurfer
         code={src}
@@ -17,6 +20,13 @@ class Code extends React.PureComponent {
   }
 }
 
+const NotesOrCode = props =>
+  getLanguage(props.className) === "notes" ? (
+    <Notes {...props} />
+  ) : (
+    <Code {...props} />
+  );
+
 export default {
-  code: Code
+  code: NotesOrCode
 };

--- a/packages/mdx-deck-code-surfer/src/deck-components.js
+++ b/packages/mdx-deck-code-surfer/src/deck-components.js
@@ -2,14 +2,14 @@ import React from "react";
 import { Notes } from "mdx-deck";
 import DeckCodeSurfer from "./deck-code-surfer";
 
-const getLanguage = className => className.slice(9);
-
 class Code extends React.PureComponent {
   render() {
     const { children, metaString, className } = this.props;
     const [src, steps] = children.split("\n----");
-    const language = getLanguage(className);
-    return (
+    const language = className.slice(9);
+    return language === "notes" ? (
+      <Notes {...this.props} />
+    ) : (
       <DeckCodeSurfer
         code={src}
         steps={steps}
@@ -20,13 +20,6 @@ class Code extends React.PureComponent {
   }
 }
 
-const NotesOrCode = props =>
-  getLanguage(props.className) === "notes" ? (
-    <Notes {...props} />
-  ) : (
-    <Code {...props} />
-  );
-
 export default {
-  code: NotesOrCode
+  code: Code
 };

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Code Surfer <🏄/>
 
-![](https://flat.badgen.net/npm/v/code-surfer) ![](https://flat.badgen.net/travis/pomber/code-surfer) 
+![](https://flat.badgen.net/npm/v/code-surfer) ![](https://flat.badgen.net/travis/pomber/code-surfer)
 
 React component for scrolling, zooming and highlighting code.
 
@@ -61,6 +61,7 @@ More options:
 ## Contributing
 
 Release new versions with:
+
 ```bash
 $ yarn build:packages
 $ npx lerna publish


### PR DESCRIPTION
I noticed after trying the `Use Code Blocks instead of JSX` feature that notes were rendering as code blocks and not appearing in presenter mode. This PR should fix that!