### PR TITLE
Allow explicitly passing Prism prop to CodeSurfer

### DIFF
--- a/packages/code-surfer/src/code-surfer.js
+++ b/packages/code-surfer/src/code-surfer.js
@@ -23,13 +23,15 @@ const CodeSurfer = ({
   showNumbers,
   dark,
   theme,
-  monospace
+  monospace,
+  Prism
 }) => {
   const selectedTokens = new SelectedTokens(step);
 
   return (
     <Highlight
       {...defaultProps}
+      Prism={Prism || defaultProps.Prism}
       code={code}
       language={lang || "jsx"}
       theme={theme !== undefined ? theme : dark ? darkTheme : lightTheme}

--- a/packages/mdx-deck-code-surfer/src/deck-code-surfer-split.js
+++ b/packages/mdx-deck-code-surfer/src/deck-code-surfer-split.js
@@ -43,7 +43,8 @@ export default withDeck(
           stepsBottom,
           title,
           showNumbers,
-          notes
+          notes,
+          Prism
         } = this.props;
         const { step, mode } = this.props.deck;
         const currentStepTop =
@@ -67,6 +68,7 @@ export default withDeck(
                 code={codeTop}
                 step={currentStepTop}
                 showNumbers={showNumbers}
+                Prism={Prism}
               />
             </div>
             <div style={{ height: "25px" }} />
@@ -78,6 +80,7 @@ export default withDeck(
                 code={codeBottom}
                 step={currentStepBottom}
                 showNumbers={showNumbers}
+                Prism={Prism}
               />
             </div>
             <div style={{ height: "25px" }} />

--- a/packages/mdx-deck-code-surfer/src/deck-components.js
+++ b/packages/mdx-deck-code-surfer/src/deck-components.js
@@ -4,7 +4,7 @@ import DeckCodeSurfer from "./deck-code-surfer";
 
 class Code extends React.PureComponent {
   render() {
-    const { children, metaString, className } = this.props;
+    const { children, metaString, className, Prism } = this.props;
     const [src, steps] = children.split("\n----");
     const language = className.slice(9);
     return language === "notes" ? (
@@ -15,6 +15,7 @@ class Code extends React.PureComponent {
         steps={steps}
         title={metaString}
         lang={language}
+        Prism={Prism}
       />
     );
   }


### PR DESCRIPTION
Need this to easily configure language such as Lisp with code surfer.
Unless there is a better way? But couldn't find docs straight away.

Feedback welcome.