### PR TITLE
Line Annotations

### DIFF
--- a/packages/code-surfer/src/code-surfer.js
+++ b/packages/code-surfer/src/code-surfer.js
@@ -74,7 +74,7 @@ const CodeSurfer = ({
                       })}
                     />
                   ))}
-                  {step.lineAnnotations && step.lineAnnotations[i]
+                  {step.lineAnnotations && step.lineAnnotations[lineNumber]
                     ? typeof step.lineAnnotations[lineNumber] === "function"
                       ? step.lineAnnotations[lineNumber]()
                       : step.lineAnnotations[lineNumber]

--- a/packages/code-surfer/src/code-surfer.js
+++ b/packages/code-surfer/src/code-surfer.js
@@ -72,6 +72,11 @@ const CodeSurfer = ({
                     })}
                   />
                 ))}
+                {step.lineAnnotations && step.lineAnnotations[i]
+                  ? typeof step.lineAnnotations[i] === "function"
+                    ? step.lineAnnotations[i]()
+                    : step.lineAnnotations[i]
+                  : null}
               </div>
             ))}
           </Scroller.Content>

--- a/packages/code-surfer/src/code-surfer.js
+++ b/packages/code-surfer/src/code-surfer.js
@@ -44,41 +44,44 @@ const CodeSurfer = ({
           })}
         >
           <Scroller.Content type="code" style={{ fontFamily: monospace }}>
-            {tokens.map((line, i) => (
-              <div {...getLineProps({ line, key: i })}>
-                {showNumbers && (
-                  <span
-                    className={
-                      "token comment " +
-                      (selectedTokens.isLineSelected(i)
-                        ? selectedRules
-                        : unselectedRules)
-                    }
-                    style={{ userSelect: "none" }}
-                  >
-                    {(i + 1 + ".").padStart(3)}{" "}
-                  </span>
-                )}
-                {line.map((token, key) => (
-                  <Scroller.Element
-                    type="span"
-                    {...getTokenProps({
-                      token,
-                      key,
-                      selected: selectedTokens.isTokenSelected(i, key),
-                      className: selectedTokens.isTokenSelected(i, key)
-                        ? selectedRules
-                        : unselectedRules
-                    })}
-                  />
-                ))}
-                {step.lineAnnotations && step.lineAnnotations[i]
-                  ? typeof step.lineAnnotations[i] === "function"
-                    ? step.lineAnnotations[i]()
-                    : step.lineAnnotations[i]
-                  : null}
-              </div>
-            ))}
+            {tokens.map((line, i) => {
+              const lineNumber = i + 1;
+              return (
+                <div {...getLineProps({ line, key: i })}>
+                  {showNumbers && (
+                    <span
+                      className={
+                        "token comment " +
+                        (selectedTokens.isLineSelected(i)
+                          ? selectedRules
+                          : unselectedRules)
+                      }
+                      style={{ userSelect: "none" }}
+                    >
+                      {(lineNumber + ".").padStart(3)}{" "}
+                    </span>
+                  )}
+                  {line.map((token, key) => (
+                    <Scroller.Element
+                      type="span"
+                      {...getTokenProps({
+                        token,
+                        key,
+                        selected: selectedTokens.isTokenSelected(i, key),
+                        className: selectedTokens.isTokenSelected(i, key)
+                          ? selectedRules
+                          : unselectedRules
+                      })}
+                    />
+                  ))}
+                  {step.lineAnnotations && step.lineAnnotations[i]
+                    ? typeof step.lineAnnotations[lineNumber] === "function"
+                      ? step.lineAnnotations[lineNumber]()
+                      : step.lineAnnotations[lineNumber]
+                    : null}
+                </div>
+              );
+            })}
           </Scroller.Content>
         </Scroller.Container>
       )}

--- a/packages/code-surfer/src/step-parser.js
+++ b/packages/code-surfer/src/step-parser.js
@@ -67,7 +67,10 @@ const getTokensPerLineFromString = step => {
 export const mapStep = step => {
   if (typeof step === "string") {
     return getTokensPerLineFromString(step);
-  } else if (Object.keys(step).length === 0) {
+  } else if (
+    Object.keys(step).length === 0 ||
+    (Object.keys(step).length === 1 && step.lineAnnotations)
+  ) {
     return { all: true };
   } else {
     return getTokensPerLineFromObject(step);


### PR DESCRIPTION
Hi! First of all, thanks for this great project! It's super useful.

I'm creating teaching materials (course material) with this tool, and I would like to annotate certain parts of the source code with arrows, indicators, labels and other diagram elements that are not in monospace font (see examples below) - some similarities to LaTeX brackets / parentheses / braces. I tried to use the current APIs, but I didn't get very far.

I ended up creating an MVP solution (described below) and I wanted to get feedback on it :)

### TODO

- [ ] [add a slide to the sample deck](https://github.com/pomber/code-surfer/pull/51#issuecomment-468951095)

### Ideal Examples

<img width="717" alt="screen shot 2019-02-26 at 15 03 20" src="https://user-images.githubusercontent.com/1935696/53565228-23c8c880-3b59-11e9-9c89-390bed01ff3e.png">

![what-is-an-xml-element](https://user-images.githubusercontent.com/1935696/53565233-27f4e600-3b59-11e9-92df-ebb1b7167d3e.png)

![images](https://user-images.githubusercontent.com/1935696/53565265-44911e00-3b59-11e9-9dd1-f87d83cc4787.png)

![698932](https://user-images.githubusercontent.com/1935696/53565289-58d51b00-3b59-11e9-8b64-8fe5326b3987.png)
![css-selectors-lrg](https://user-images.githubusercontent.com/1935696/53565290-58d51b00-3b59-11e9-97b1-4a10ae5a2c68.png)

### Current MVP Solution

In order to do the very minimum of implementation work with the largest impact, I have created an MVP for only line annotations that allows for strings and React components to be passed via a new property called `lineAnnotations` in the step object, which is an object mapping lines to their annotation content.

The MVP is currently published under `@upleveled/mdx-deck-code-surfer@0.6.3` (depends on `@upleveled/code-surfer@0.6.1`).

To try it out:

```
yarn add --dev @upleveled/mdx-deck-code-surfer
```

It allows for things like this:

![kapture 2019-02-28 at 12 51 48](https://user-images.githubusercontent.com/1935696/53565421-bec1a280-3b59-11e9-8879-12567ed06448.gif)

via this code:

```js
<CodeSurfer
  title="Example of HTML code"
  code={require('!raw-loader!./first-example.html')}
  lang="markup"
  steps={[
    {},
    {
      lineAnnotations: {
        4: (
          <span style={{ fontFamily: 'BlinkMacSystemFont' }}>
            {' '}
            <Arrow
              angle={270}
              length={300}
              style={{
                verticalAlign: '-4px',
                width: '300px',
              }}
              color="white"
            /> Opening Tag
          </span>
        ),
        6: (
          <span style={{ fontFamily: 'BlinkMacSystemFont' }}>
            {' '}
            <Arrow
              angle={270}
              length={292}
              style={{
                verticalAlign: '-4px',
                width: '292px',
              }}
              color="white"
            /> Closing Tag
          </span>
        ),
      },
    },
  ]}
/>
```

---

What are your opinions of this API?

More specifically:

1. Do you have any recommendations on a better way to achieve what I'm intending here?
2. Should I use `Scroller.Element` at all?
3. Should this API be more generalized? More like:
```
interface Step {
  annotations?: {
    lines?: {
      [key: number]: JSX.Element | string
    }
  }
}
```
4. Should I update the `step-parser.js` test file?