### PR TITLE
Allow overriding container styles

### DIFF
--- a/packages/mdx-deck-code-surfer/src/deck-code-surfer.js
+++ b/packages/mdx-deck-code-surfer/src/deck-code-surfer.js
@@ -57,6 +57,7 @@ class InnerCodeSurfer extends React.Component {
       theme,
       prismTheme,
       showNumbers,
+      containerStyles,
       ...rest
     } = this.props;
 
@@ -82,12 +83,13 @@ class InnerCodeSurfer extends React.Component {
           color: prismTheme && prismTheme.plain.color,
           display: "flex",
           alignItems: "center",
-          justifyContent: "center"
+          justifyContent: "center",
+          ...(containerStyles || {})
         }}
       >
         <div
           style={{
-            height: "100vh",
+            height: (containerStyles && containerStyles.height) || "100vh",
             display: "flex",
             flexDirection: "column",
             justifyContent: "center"


### PR DESCRIPTION
MVP for https://github.com/pomber/code-surfer/issues/44#issuecomment-469075931

```jsx
<div
  style={{
    height: '100vh',
    display: 'flex',
    flexDirection: 'column',
  }}
>
  <div style={{ flex: 1, overflow: 'hidden' }} key="codeTop">
    <CodeSurfer
      code={require('!raw-loader!./example-1.html')}
      lang="markup"
      containerStyles={{ height: '100%', width: '100%', padding: '10px' }}
    />
  </div>
  <div style={{ height: '2px', backgroundColor: '#333' }} />
  <div style={{ flex: 1, overflow: 'hidden' }} key="codeBottom">
    <CodeSurfer
      code={require('!raw-loader!./example-1.css')}
      lang="css"
      containerStyles={{ height: '100%', width: '100%', padding: '10px' }}
    />
  </div>
</div>
```


**Before:**

<img width="798" alt="screen shot 2019-03-04 at 00 08 23" src="https://user-images.githubusercontent.com/1935696/53703459-8d273080-3e12-11e9-984d-d7700d2ffc8b.png">


**After:**

<img width="666" alt="screen shot 2019-03-04 at 00 13 03" src="https://user-images.githubusercontent.com/1935696/53703460-91ebe480-3e12-11e9-9de4-7db55cb456d0.png">