### PR TITLE
Export makeTheme for external use

### DIFF
--- a/packs/themes/src/index.ts
+++ b/packs/themes/src/index.ts
@@ -9,7 +9,7 @@ export { theme as shadesOfPurple } from "./theme.shades-of-purple";
 export { theme as ultramin } from "./theme.ultramin";
 export { theme as vsDark } from "./theme.vs-dark";
 
-export { CodeSurferTheme } from "./utils";
+export { CodeSurferTheme, makeTheme } from "./utils";
 export {
   StylesProvider,
   Styled,


### PR DESCRIPTION
Hi @pomber ! 👋 Long time no speak.

I would like to use the `makeTheme` function elsewhere in my code (to create custom themes based on other `prism-react-renderer` themes).

Would it be possible to export it like this?