### PR TITLE
Improve theme styles

### DIFF
--- a/packs/themes/src/theme.vs-dark.ts
+++ b/packs/themes/src/theme.vs-dark.ts
@@ -21,7 +21,7 @@ const prismTheme: PrismTheme = {
       }
     },
     {
-      types: ["builtin", "changed", "keyword"],
+      types: ["builtin", "changed", "keyword", "interpolation-punctuation"],
       style: {
         color: "rgb(86, 156, 214)"
       }
@@ -45,7 +45,7 @@ const prismTheme: PrismTheme = {
       }
     },
     {
-      types: ["deleted", "string", "attr-value"],
+      types: ["deleted", "string", "attr-value", "template-punctuation"],
       style: {
         color: "rgb(206, 145, 120)"
       }


### PR DESCRIPTION
Hi @pomber ! 👋 Hope you are well!

Here's a small PR to slightly improve the VS Code Dark (`vsDark`) theme.

Before:

![Screen Shot 2021-05-15 at 15 33 42](https://user-images.githubusercontent.com/1935696/118363330-21b17f80-b594-11eb-8b04-1efaba5c50a0.png)

After:

![Screen Shot 2021-05-15 at 15 35 12](https://user-images.githubusercontent.com/1935696/118363322-1c543500-b594-11eb-87db-8c5b38e65614.png)

Real VS Code:

<img width="185" alt="Screen Shot 2021-05-15 at 15 35 17" src="https://user-images.githubusercontent.com/1935696/118363317-13fbfa00-b594-11eb-8edd-3e3b4fbec1b6.png">
