### PR TITLE
Add Line Annotations

### DIFF
--- a/packs/standalone/src/lines.tsx
+++ b/packs/standalone/src/lines.tsx
@@ -235,6 +235,7 @@ export function LineList({
                       {token}
                     </span>
                   ))}
+                {stepPair.prev.annotations[lineKey + 1]}
               </div>
             </div>
           )

--- a/packs/standalone/src/lines.tsx
+++ b/packs/standalone/src/lines.tsx
@@ -235,7 +235,7 @@ export function LineList({
                       {token}
                     </span>
                   ))}
-                {stepPair.prev.annotations[lineKey + 1]}
+                {stepPair.prev.annotations?.[lineKey + 1]}
               </div>
             </div>
           )

--- a/packs/step-parser/src/step-parser.ts
+++ b/packs/step-parser/src/step-parser.ts
@@ -41,6 +41,7 @@ export function parseSteps(
     longestLineIndex: number;
     title?: string;
     subtitle?: string;
+    annotations: Record<number, React.ReactNode>;
   }[] = [];
 
   steps.forEach((step, i) => {
@@ -67,7 +68,8 @@ export function parseSteps(
       focusCount,
       longestLineIndex: getLongestLineIndex(code),
       title: inputSteps[i].title,
-      subtitle: inputSteps[i].subtitle
+      subtitle: inputSteps[i].subtitle,
+      annotations: inputSteps[i].annotations
     });
   });
 


### PR DESCRIPTION
Followup to https://github.com/pomber/code-surfer/pull/51 with the new version of Code Surfer

@pomber what are your thoughts on this?

Simple example:

```jsx
<CodeSurfer
  steps={[
    {
      code: `This line will have an "abc" annotation here ->
This line will have an "def" annotation here ->`,
      lang: 'jsx',
      annotations: {
        1: <span>abc</span>,
        2: <span>def</span>,
      },
    },
  ]}
  progress={0}
/>
```

More complex example:

```jsx
<CodeSurfer
  lang="jsx"
  steps={[
    {
      code: require('!raw-loader!./packages/example-1-simple-cra/src/index.js'),
      lang: 'jsx',
      annotations: {
        1: (
          <Brace side="left" height="5em">
            JavaScript
          </Brace>
        ),
        8: (
          <Brace side="right" height="3em" style={{}}>
            JSX
          </Brace>
        ),
        13: (
          <Brace side="left" height="3em">
            JavaScript
          </Brace>
        ),
        22: (
          <Brace side="right" height="6em" style={{ marginTop: '-2.5em' }}>
            JSX
          </Brace>
        ),
        27: (
          <>
            <Brace side="top" width="5.7em" style={{ marginLeft: '-1.3em' }}>
              JavaScript
            </Brace>
            <Brace side="top" width="2.2em" style={{ marginLeft: '5.2em' }}>
              JSX
            </Brace>
            <Brace side="top" width="13.3em" style={{ marginLeft: '8.2em' }}>
              JavaScript
            </Brace>
          </>
        ),
      },
    },
  ]}
  progress={0}
/>
```

![Screen Shot 2021-05-15 at 19 06 28](https://user-images.githubusercontent.com/1935696/118372215-c6da5100-b5b0-11eb-947d-549e798e598f.png)
